### PR TITLE
feat: move dependencies to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,18 @@
 [workspace]
 default-members = ["crates/*"]
 members = ["crates/*", "examples/*"]
+
+[workspace.dependencies]
+uuid = { version = "0.8.1", features = ["serde", "v4"] }
+serde = { version = "1.0.117", features = ["derive"] }
+sqlx = { version = "0.5.9", features = ["chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
+async-trait = "0.1.51"
+serde_json = "1.0.68"
+actix = "0.12.0"
+futures = "0.3.17"
+log = "0.4.14"
+tokio = { version = "1.12.0", features = ["full"] }
+tracing = "0.1.28"
+tracing-futures = "0.2.5"
+
+

--- a/crates/chekov/Cargo.toml
+++ b/crates/chekov/Cargo.toml
@@ -12,24 +12,23 @@ categories = []
 authors = ["Freyskeyd <simon.paitrault@gmail.com>"]
 
 [dependencies]
+uuid.workspace = true
+serde.workspace = true
+sqlx.workspace = true
+async-trait.workspace = true
+serde_json.workspace = true
+actix.workspace = true
+futures.workspace = true
+log.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-futures.workspace = true
+
 event_store = { version = "0.1", path = "../event_store" }
 chekov-macros = { version = "0.1", path = "../chekov-macros" }
 fnv = "1.0.7"
 chrono = "0.4.19"
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
 # Until next minor
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
-async-trait = "0.1.51"
-serde = "1.0.130"
-serde_json = "1.0.68"
-actix = "0.12.0"
-futures = "0.3.17"
-log = "0.4.14"
-tokio = { version = "1.12.0", features = ["full"] }
-
-tracing = "0.1.28"
-tracing-futures = "0.2.5"
-
 inventory = "0.1.10"
 lazy_static = "1.4.0"
 typetag = "0.1.7"

--- a/crates/event_store-backend-inmemory/Cargo.toml
+++ b/crates/event_store-backend-inmemory/Cargo.toml
@@ -6,16 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uuid.workspace = true
+tracing.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+futures.workspace = true
 
 event_store-core = { version = "0.1.0", path = "../event_store-core" }
 chrono = { version = "0.4.19", features = ["serde"] }
-tokio = { version = "1.12.0", features = ["full"] }
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-serde_json = "1.0.68"
-log = "0.4.14"
-tracing = "0.1.28"
-tracing-futures = "0.2.5"
-futures = "0.3.17"
 async-stream = "0.3"
 
 [dev-dependencies]

--- a/crates/event_store-backend-postgres/Cargo.toml
+++ b/crates/event_store-backend-postgres/Cargo.toml
@@ -6,17 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1.0.130"
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
+uuid.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+sqlx.workspace = true
+futures.workspace = true
+
 event_store-core = { version = "0.1.0", path = "../event_store-core" }
-chrono = { version = "0.4.19", features = ["serde"] }
-tokio = { version = "1.12.0", features = ["full"] }
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-serde_json = "1.0.68"
-log = "0.4.14"
-tracing = "0.1.28"
-tracing-futures = "0.2.5"
-futures = "0.3.17"
 thiserror = "1.0"
 async-stream = "0.3"
 

--- a/crates/event_store-backend-postgres/src/sql.rs
+++ b/crates/event_store-backend-postgres/src/sql.rs
@@ -3,12 +3,12 @@ use event_store_core::event::RecordedEvent;
 use event_store_core::event::UnsavedEvent;
 use event_store_core::stream::Stream;
 use futures::StreamExt;
-use log::trace;
 use sqlx::pool::PoolConnection;
 use sqlx::postgres::PgRow;
 use sqlx::Postgres;
 use sqlx::Row;
 use std::convert::TryInto;
+use tracing::trace;
 use uuid::Uuid;
 
 use crate::error::PostgresBackendError;

--- a/crates/event_store-core/Cargo.toml
+++ b/crates/event_store-core/Cargo.toml
@@ -8,17 +8,16 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = { version = "0.12.0", optional = true }
+actix = { workspace = true, optional = true }
+futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+tokio.workspace = true
+uuid.workspace = true
+
 chrono = { version = "0.4.19", features = ["serde"] }
-futures = "0.3.17"
-log = "0.4.14"
-serde = "1.0.130"
-serde_json = "1.0.68"
-erased-serde = "0.3"
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
 thiserror = "1.0"
-tokio = { version = "1.12.0", features = ["full"] }
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
 
 [features]
 default = ["actix-rt"]

--- a/crates/event_store-eventbus-inmemory/Cargo.toml
+++ b/crates/event_store-eventbus-inmemory/Cargo.toml
@@ -6,19 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-serde = "1.0.130"
-serde_json = "1.0.68"
-async-trait = "0.1.51"
-tokio = { version = "1.12.0", features = ["full"] }
-futures = "0.3.17"
-log = "0.4.14"
-actix = "0.12.0"
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
-chrono = { version = "0.4.19", features = ["serde"] }
+uuid.workspace = true
+serde.workspace = true
+actix.workspace = true
+futures.workspace = true
+tokio.workspace = true
 
-tracing = "0.1.28"
-tracing-futures = "0.2.5"
 async-stream = "0.3"
 
 event_store-core = { version = "0.1.0", path = "../event_store-core" }

--- a/crates/event_store-eventbus-postgres/Cargo.toml
+++ b/crates/event_store-eventbus-postgres/Cargo.toml
@@ -3,24 +3,10 @@ name = "event_store-eventbus-postgres"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-serde = "1.0.130"
-serde_json = "1.0.68"
-async-trait = "0.1.51"
-tokio = { version = "1.12.0", features = ["full"] }
-futures = "0.3.17"
-log = "0.4.14"
-actix = "0.12.0"
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
-chrono = { version = "0.4.19", features = ["serde"] }
-
-tracing = "0.1.28"
-tracing-futures = "0.2.5"
-async-stream = "0.3"
+uuid.workspace = true
+serde.workspace = true
+sqlx = { workspace = true, features = ["postgres"] }
+futures.workspace = true
 
 event_store-core = { version = "0.1.0", path = "../event_store-core" }
-
-

--- a/crates/event_store-storage-postgres/Cargo.toml
+++ b/crates/event_store-storage-postgres/Cargo.toml
@@ -10,8 +10,5 @@ event_store-core = { version = "0.1.0", path = "../event_store-core" }
 event_store-backend-postgres = { version = "0.1.0", path = "../event_store-backend-postgres" }
 event_store-eventbus-postgres = { version = "0.1.0", path = "../event_store-eventbus-postgres" }
 
-chrono = { version = "0.4.19", features = ["serde"] }
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
-tokio = { version = "1.12.0", features = ["full"] }
-tracing = "0.1.28"
-tracing-futures = "0.2.5"
+sqlx.workspace = true
+tracing.workspace = true

--- a/crates/event_store/Cargo.toml
+++ b/crates/event_store/Cargo.toml
@@ -9,20 +9,13 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-serde = "1.0.130"
-serde_json = "1.0.68"
-async-trait = "0.1.51"
-tokio = { version = "1.12.0", features = ["full"] }
-futures = "0.3.17"
-log = "0.4.14"
-actix = "0.12.0"
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
-chrono = { version = "0.4.19", features = ["serde"] }
-
-tracing = "0.1.28"
-tracing-futures = "0.2.5"
-async-stream = "0.3"
+uuid.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+actix.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+futures.workspace = true
 
 event_store-core = { version = "0.1.0", path = "../event_store-core" }
 

--- a/crates/watcher/Cargo.toml
+++ b/crates/watcher/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uuid.workspace = true
+futures.workspace = true
+sqlx.workspace = true
+tokio.workspace = true
+
 event_store = { version = "0.1", path = "../event_store" }
-tokio = { version = "1.12.0", features = ["full"] }
-futures = "0.3.17"
 tui = "0.18"
 crossterm = "0.23"
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "offline", "runtime-actix-native-tls"] }
-
-uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/examples/bank/Cargo.toml
+++ b/examples/bank/Cargo.toml
@@ -6,21 +6,15 @@ edition = "2018"
 workspace = "../../"
 
 [dependencies]
+actix.workspace = true
+futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+uuid.workspace = true
+
 chekov = { path = "../../crates/chekov"  }
-tokio = { version = "1.12.0", features = ["full"] }
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-serde = "1.0.130"
-serde_json = "1.0.68"
-actix = "0.12.0"
-log = "0.4.14"
-futures = "0.3.17"
 actix-web = "4.0.0-beta.9"
-
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "runtime-actix-native-tls"] }
-chrono = "0.4.19"
-
-tracing = { version = "0.1.28", features = [] }
 tracing-subscriber = "0.2.24"
-tracing-futures = "0.2.5"
-tracing-log = "0.1.2"
-

--- a/examples/gift_shop/Cargo.toml
+++ b/examples/gift_shop/Cargo.toml
@@ -6,21 +6,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uuid.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+futures.workspace = true
+tokio.workspace = true
+sqlx.workspace = true
+actix.workspace = true
+
 chekov = { path = "../../crates/chekov"  }
-tokio = { version = "1.12.0", features = ["full"] }
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-serde = "1.0.130"
-serde_json = "1.0.68"
-actix = "0.12.0"
-log = "0.4.14"
-futures = "0.3.17"
 actix-web = "4.0.0-beta.9"
-
-sqlx = { version = "0.5.9", features = ["postgres", "chrono", "time", "uuid", "json", "runtime-actix-native-tls"] }
-chrono = "0.4.19"
-
-tracing = { version = "0.1.28", features = [] }
 tracing-subscriber = "0.2.24"
-tracing-futures = "0.2.5"
-tracing-log = "0.1.2"
-


### PR DESCRIPTION
This PR moves some common dependencies from nested `Cargo.toml` to the root `Cargo.toml` in order to use the freshly landed feature, allowing us to manage global dependencies across workspace crates.